### PR TITLE
[August] 미션3: 체스판 초기화

### DIFF
--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -54,16 +54,5 @@ public class Board {
         return sb.toString();
     }
 
-    void print() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("........\n");
-        sb.append(getBlackPawnsResult()).append("\n");
-        for (int i = 0; i < BOARD_SIZE - 4; i++) {
-            sb.append("........\n");
-        }
-        sb.append(getWhitePawnsResult()).append("\n");
-        sb.append("........\n");
 
-        System.out.println(sb.toString());
-    }
 }

--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -8,22 +8,8 @@ import java.util.List;
 
 public class Board {
     public static final int BOARD_SIZE = 8;
-    private final List<Piece> whitePieces;
-    private final List<Piece> blackPieces;
-
-    public Board() {
-        whitePieces = new ArrayList<>();
-        blackPieces = new ArrayList<>();
-        initialize();
-    }
-
-    public void add(Piece piece) {
-        if (piece.getColor().equals(Piece.WHITE_COLOR)) {
-            whitePieces.add(piece);
-        } else {
-            blackPieces.add(piece);
-        }
-    }
+    private final List<Piece> whitePieces = new ArrayList<>();
+    private final List<Piece> blackPieces = new ArrayList<>();
 
     public void addBlack(Piece piece) {
         blackPieces.add(piece);
@@ -47,16 +33,37 @@ public class Board {
 
     void initialize() {
         for (int i = 0; i < BOARD_SIZE; i++) {
-            add(new Pawn(Piece.WHITE_COLOR, Pawn.WHITE_REPRESENTATION));
-            add(new Pawn(Piece.BLACK_COLOR, Pawn.BLACK_REPRESENTATION));
+            addWhite(new Pawn(Piece.WHITE_COLOR, Pawn.WHITE_REPRESENTATION));
+            addBlack(new Pawn(Piece.BLACK_COLOR, Pawn.BLACK_REPRESENTATION));
         }
     }
 
     String getWhitePawnsResult() {
-        return "";
+        return getPiecesResult(whitePieces);
     }
 
     String getBlackPawnsResult() {
-        return "";
+        return getPiecesResult(blackPieces);
+    }
+
+    private String getPiecesResult(List<Piece> pieces) {
+        StringBuilder sb = new StringBuilder();
+        for (Piece piece : pieces) {
+            sb.append(piece.getRepresentation());
+        }
+        return sb.toString();
+    }
+
+    void print() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("........\n");
+        sb.append(getBlackPawnsResult()).append("\n");
+        for (int i = 0; i < BOARD_SIZE - 4; i++) {
+            sb.append("........\n");
+        }
+        sb.append(getWhitePawnsResult()).append("\n");
+        sb.append("........\n");
+
+        System.out.println(sb.toString());
     }
 }

--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -1,33 +1,62 @@
 package chess;
 
+import pieces.Pawn;
 import pieces.Piece;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class Board {
-    private final List<Piece> board = new ArrayList<>();
+    public static final int BOARD_SIZE = 8;
+    private final List<Piece> whitePieces;
+    private final List<Piece> blackPieces;
+
+    public Board() {
+        whitePieces = new ArrayList<>();
+        blackPieces = new ArrayList<>();
+        initialize();
+    }
 
     public void add(Piece piece) {
-        board.add(piece);
+        if (piece.getColor().equals(Piece.WHITE_COLOR)) {
+            whitePieces.add(piece);
+        } else {
+            blackPieces.add(piece);
+        }
+    }
+
+    public void addBlack(Piece piece) {
+        blackPieces.add(piece);
+    }
+
+    public void addWhite(Piece piece) {
+        whitePieces.add(piece);
     }
 
     public int size() {
-        return board.size();
+        return whitePieces.size() + blackPieces.size();
     }
 
-    public Piece findPawn(int index) {
-        return board.get(index);
+    public Piece findWhite(int index) {
+        return whitePieces.get(index);
     }
 
-    public void initialize() {
+    public Piece findBlack(int index) {
+        return blackPieces.get(index);
     }
 
-    public String getWhitePawnsResult() {
+    void initialize() {
+        for (int i = 0; i < BOARD_SIZE; i++) {
+            add(new Pawn(Piece.WHITE_COLOR, Pawn.WHITE_REPRESENTATION));
+            add(new Pawn(Piece.BLACK_COLOR, Pawn.BLACK_REPRESENTATION));
+        }
+    }
+
+    String getWhitePawnsResult() {
         return "";
     }
 
-    public String getBlackPawnsResult() {
+    String getBlackPawnsResult() {
         return "";
     }
 }

--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -19,4 +19,15 @@ public class Board {
     public Piece findPawn(int index) {
         return board.get(index);
     }
+
+    public void initialize() {
+    }
+
+    public String getWhitePawnsResult() {
+        return "";
+    }
+
+    public String getBlackPawnsResult() {
+        return "";
+    }
 }

--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -11,12 +11,16 @@ public class Board {
     private final List<Piece> whitePieces = new ArrayList<>();
     private final List<Piece> blackPieces = new ArrayList<>();
 
-    public void addBlack(Piece piece) {
-        blackPieces.add(piece);
+    public void addWhite(Piece piece) {
+        if (piece.getColor().equals(Piece.WHITE_COLOR)) {
+            whitePieces.add(piece);
+        }
     }
 
-    public void addWhite(Piece piece) {
-        whitePieces.add(piece);
+    public void addBlack(Piece piece) {
+        if (piece.getColor().equals(Piece.BLACK_COLOR)) {
+            blackPieces.add(piece);
+        }
     }
 
     public int size() {
@@ -53,6 +57,5 @@ public class Board {
         }
         return sb.toString();
     }
-
 
 }

--- a/src/main/java/chess/Game.java
+++ b/src/main/java/chess/Game.java
@@ -1,0 +1,30 @@
+package chess;
+
+import java.util.Scanner;
+
+public class Game {
+    public static void main(String[] args) {
+        Scanner scanner = new Scanner(System.in);
+
+        System.out.println("Play the chess!");
+        System.out.println("To start, input \"start\" and \"end\" to quit.");
+
+        while (true) {
+            System.out.print("> ");
+            String command = scanner.nextLine();
+            command = command.toLowerCase();
+            if (command.equals("start")) {
+                Board board = new Board();
+                board.initialize();
+                board.print();
+            } else if (command.equals("end")) {
+                break;
+            } else {
+                System.out.println(command + " not supported.");
+            }
+        }
+
+        System.out.println("Goodbye..");
+        scanner.close();
+    }
+}

--- a/src/main/java/chess/Game.java
+++ b/src/main/java/chess/Game.java
@@ -9,22 +9,40 @@ public class Game {
         System.out.println("Play the chess!");
         System.out.println("To start, input \"start\" and \"end\" to quit.");
 
+        process(scanner);
+
+        System.out.println("Goodbye..");
+        scanner.close();
+    }
+
+    static void process(Scanner scanner) {
         while (true) {
             System.out.print("> ");
             String command = scanner.nextLine();
             command = command.toLowerCase();
+
             if (command.equals("start")) {
                 Board board = new Board();
                 board.initialize();
-                board.print();
+                print(board);
             } else if (command.equals("end")) {
                 break;
             } else {
                 System.out.println(command + " not supported.");
             }
         }
+    }
 
-        System.out.println("Goodbye..");
-        scanner.close();
+    static void print(Board board) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("........\n");
+        sb.append(board.getBlackPawnsResult()).append("\n");
+        for (int i = 0; i < Board.BOARD_SIZE - 4; i++) {
+            sb.append("........\n");
+        }
+        sb.append(board.getWhitePawnsResult()).append("\n");
+        sb.append("........\n");
+
+        System.out.println(sb.toString());
     }
 }

--- a/src/main/java/pieces/Pawn.java
+++ b/src/main/java/pieces/Pawn.java
@@ -1,13 +1,19 @@
 package pieces;
 
 public class Pawn extends Piece {
+    public static final char BLACK_REPRESENTATION = 'P';
+    public static final char WHITE_REPRESENTATION = 'p';
 
     public Pawn() {
-        super(Piece.WHITE_COLOR);
+        super(Piece.WHITE_COLOR, Pawn.WHITE_REPRESENTATION);
     }
 
     public Pawn(String color) {
-        super(color);
+        super(color, Pawn.WHITE_REPRESENTATION);
+    }
+
+    public Pawn(String color, char representation) {
+        super(color, representation);
     }
 
     public String getColor() {

--- a/src/main/java/pieces/Pawn.java
+++ b/src/main/java/pieces/Pawn.java
@@ -19,4 +19,8 @@ public class Pawn extends Piece {
     public String getColor() {
         return super.getColor();
     }
+
+    public char getRepresentation() {
+        return super.getRepresentation();
+    }
 }

--- a/src/main/java/pieces/Piece.java
+++ b/src/main/java/pieces/Piece.java
@@ -5,9 +5,11 @@ public abstract class Piece {
     public static final String BLACK_COLOR = "black";
 
     private final String color;
+    private final char representation;
 
-    public Piece(String color) {
+    public Piece(String color, char representation) {
         this.color = color;
+        this.representation = representation;
     }
 
     public String getColor() {

--- a/src/main/java/pieces/Piece.java
+++ b/src/main/java/pieces/Piece.java
@@ -15,4 +15,8 @@ public abstract class Piece {
     public String getColor() {
         return color;
     }
+
+    public char getRepresentation() {
+        return representation;
+    }
 }

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -2,7 +2,8 @@ package chess;
 
 import org.junit.jupiter.api.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import pieces.Pawn;
 import pieces.Piece;
@@ -33,21 +34,22 @@ public class BoardTest {
     public void initialize() throws Exception {
         Board board = new Board();
         board.initialize();
-        assertEquals("pppppppp", board.getWhitePawnsResult());
-        assertEquals("PPPPPPPP", board.getBlackPawnsResult());
+        assertAll(
+                ()->assertThat("pppppppp").isEqualTo(board.getWhitePawnsResult()),
+                ()->assertThat("PPPPPPPP").isEqualTo(board.getBlackPawnsResult())
+        );
     }
 
     void verifySize(int expectedSize) {
-        assertEquals(expectedSize, board.size());
+        assertThat(expectedSize).isEqualTo(board.size());
     }
 
     void verifyFindPawn(Piece piece, int index) {
         if (piece.getColor().equals(Piece.WHITE_COLOR)) {
-            assertEquals(piece, board.findWhite(index));
+            assertThat(piece).isEqualTo(board.findWhite(index));
         } else {
-            assertEquals(piece, board.findBlack(index));
+            assertThat(piece).isEqualTo(board.findBlack(index));
         }
-
     }
 
     Piece add(String color) {

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -32,7 +32,6 @@ public class BoardTest {
     @Test
     @DisplayName("Init board")
     public void initialize() throws Exception {
-        Board board = new Board();
         board.initialize();
         assertAll(
                 ()->assertThat("pppppppp").isEqualTo(board.getWhitePawnsResult()),

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -42,7 +42,7 @@ public class BoardTest {
     }
 
     void verifyFindPawn(Piece piece, int index) {
-        assertEquals(piece, board.findPawn(index));
+        assertEquals(piece, board.findWhite(index));
     }
 
     Piece add(String color) {

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -20,13 +20,17 @@ public class BoardTest {
     @Test
     @DisplayName("Create pawns")
     void create() throws Exception {
-        Piece white = add(Piece.WHITE_COLOR);
-        verifySize(1);
-        verifyFindPawn(white, 0);
+        Piece white = addWhitePawn(Piece.WHITE_COLOR);
+        assertAll(
+                () -> verifySize(1),
+                () -> verifyFindWhitePawn(white, 0)
+        );
 
-        Piece black = add(Piece.BLACK_COLOR);
-        verifySize(2);
-        verifyFindPawn(black, 0);
+        Piece black = addBlackPawn(Piece.BLACK_COLOR);
+        assertAll(
+                () -> verifySize(2),
+                () -> verifyFindBlackPawn(black, 0)
+        );
     }
 
     @Test
@@ -43,23 +47,23 @@ public class BoardTest {
         assertThat(expectedSize).isEqualTo(board.size());
     }
 
-    void verifyFindPawn(Piece piece, int index) {
-        if (piece.getColor().equals(Piece.WHITE_COLOR)) {
-            assertThat(piece).isEqualTo(board.findWhite(index));
-        } else {
-            assertThat(piece).isEqualTo(board.findBlack(index));
-        }
+    void verifyFindWhitePawn(Piece piece, int index) {
+        assertThat(piece).isEqualTo(board.findWhite(index));
     }
 
-    Piece add(String color) {
+    void verifyFindBlackPawn(Piece piece, int index) {
+        assertThat(piece).isEqualTo(board.findBlack(index));
+    }
+
+    Piece addWhitePawn(String color) {
         Pawn pawn = new Pawn(color);
+        board.addWhite(pawn);
+        return pawn;
+    }
 
-        if (color.equals(Piece.WHITE_COLOR)) {
-            board.addWhite(pawn);
-        } else {
-            board.addBlack(pawn);
-        }
-
+    Piece addBlackPawn(String color) {
+        Pawn pawn = new Pawn(color);
+        board.addBlack(pawn);
         return pawn;
     }
 }

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -34,8 +34,8 @@ public class BoardTest {
     public void initialize() throws Exception {
         board.initialize();
         assertAll(
-                ()->assertThat("pppppppp").isEqualTo(board.getWhitePawnsResult()),
-                ()->assertThat("PPPPPPPP").isEqualTo(board.getBlackPawnsResult())
+                () -> assertThat("pppppppp").isEqualTo(board.getWhitePawnsResult()),
+                () -> assertThat("PPPPPPPP").isEqualTo(board.getBlackPawnsResult())
         );
     }
 

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -11,13 +11,13 @@ public class BoardTest {
     private static Board board;
 
     @BeforeAll
-    @DisplayName("init board")
-    static void init() {
+    @DisplayName("Create board")
+    static void create_board() {
         board = new Board();
     }
 
     @Test
-    @DisplayName("create pawns")
+    @DisplayName("Create pawns")
     void create() throws Exception {
         Piece white = add(Piece.WHITE_COLOR);
         verifySize(1);
@@ -26,6 +26,15 @@ public class BoardTest {
         Piece black = add(Piece.BLACK_COLOR);
         verifySize(2);
         verifyFindPawn(black, 1);
+    }
+
+    @Test
+    @DisplayName("Init board")
+    public void initialize() throws Exception {
+        Board board = new Board();
+        board.initialize();
+        assertEquals("pppppppp", board.getWhitePawnsResult());
+        assertEquals("PPPPPPPP", board.getBlackPawnsResult());
     }
 
     void verifySize(int expectedSize) {

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -10,9 +10,9 @@ import pieces.Piece;
 public class BoardTest {
     private static Board board;
 
-    @BeforeAll
+    @BeforeEach
     @DisplayName("Create board")
-    static void create_board() {
+    void create_board() {
         board = new Board();
     }
 
@@ -25,7 +25,7 @@ public class BoardTest {
 
         Piece black = add(Piece.BLACK_COLOR);
         verifySize(2);
-        verifyFindPawn(black, 1);
+        verifyFindPawn(black, 0);
     }
 
     @Test
@@ -42,12 +42,23 @@ public class BoardTest {
     }
 
     void verifyFindPawn(Piece piece, int index) {
-        assertEquals(piece, board.findWhite(index));
+        if (piece.getColor().equals(Piece.WHITE_COLOR)) {
+            assertEquals(piece, board.findWhite(index));
+        } else {
+            assertEquals(piece, board.findBlack(index));
+        }
+
     }
 
     Piece add(String color) {
         Pawn pawn = new Pawn(color);
-        board.add(pawn);
+
+        if (color.equals(Piece.WHITE_COLOR)) {
+            board.addWhite(pawn);
+        } else {
+            board.addBlack(pawn);
+        }
+
         return pawn;
     }
 }

--- a/src/test/java/pieces/PawnTest.java
+++ b/src/test/java/pieces/PawnTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.*;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PawnTest {
 

--- a/src/test/java/pieces/PawnTest.java
+++ b/src/test/java/pieces/PawnTest.java
@@ -21,13 +21,20 @@ public class PawnTest {
     @DisplayName("Verify pawns")
     void create() {
         assertAll("color",
-                () -> verifyPawn(Piece.WHITE_COLOR, Pawn.WHITE_REPRESENTATION),
-                () -> verifyPawn(Piece.BLACK_COLOR, Pawn.BLACK_REPRESENTATION)
+                () -> verifyPawnColor(Piece.WHITE_COLOR),
+                () -> verifyPawnColor(Piece.BLACK_COLOR),
+                () -> verifyPawnRepresentation(Piece.WHITE_COLOR, Pawn.WHITE_REPRESENTATION),
+                () -> verifyPawnRepresentation(Piece.BLACK_COLOR, Pawn.BLACK_REPRESENTATION)
         );
     }
 
-    void verifyPawn(final String color, final char representation) {
+    void verifyPawnRepresentation(final String color, final char representation) {
         Pawn pawn = new Pawn(color, representation);
+        assertThat(pawn.getRepresentation()).isEqualTo(representation);
+    }
+
+    void verifyPawnColor(final String color) {
+        Pawn pawn = new Pawn(color);
         assertThat(pawn.getColor()).isEqualTo(color);
     }
 }

--- a/src/test/java/pieces/PawnTest.java
+++ b/src/test/java/pieces/PawnTest.java
@@ -12,7 +12,10 @@ public class PawnTest {
     @DisplayName("Verify default constructor")
     void create_default() throws Exception {
         Pawn pawn = new Pawn();
-        assertEquals(Piece.WHITE_COLOR, pawn.getColor());
+        assertAll(
+                () -> assertThat(Piece.WHITE_COLOR).isEqualTo(pawn.getColor()),
+                () -> assertThat(Pawn.WHITE_REPRESENTATION).isEqualTo(pawn.getRepresentation())
+        );
     }
 
     @Test

--- a/src/test/java/pieces/PawnTest.java
+++ b/src/test/java/pieces/PawnTest.java
@@ -19,14 +19,13 @@ public class PawnTest {
     @DisplayName("Verify pawns")
     void create() {
         assertAll("color",
-                () -> verifyPawn(Piece.WHITE_COLOR),
-                () -> verifyPawn(Piece.BLACK_COLOR)
+                () -> verifyPawn(Piece.WHITE_COLOR, Pawn.WHITE_REPRESENTATION),
+                () -> verifyPawn(Piece.BLACK_COLOR, Pawn.BLACK_REPRESENTATION)
         );
-
     }
 
-    void verifyPawn(final String color) {
-        Pawn pawn = new Pawn(color);
+    void verifyPawn(final String color, final char representation) {
+        Pawn pawn = new Pawn(color, representation);
         assertThat(pawn.getColor()).isEqualTo(color);
     }
 }


### PR DESCRIPTION
### 미션3: 체스판 초기화

안녕하세요! '미션3: 체스판 초기화'를 구현하고 주어진 테스트 코드를 실행 해보았습니다. 구현 내용은 아래와 같습니다.

### 구현 내용

#### main/pieces

- Piece.java
  - char 타입의 representation필드를 추가하여, 상속받은 체스말들이 모두 표기될 문자를 필드로 갖도록 했습니다.
  - representation에 대한 getter도 추가했습니다.
   
- Pawn.java
  - 상수 필드로 검정색 폰, 흰색 폰의 표기문자를 갖습니다.
  - 생성자 오버로딩을 통해 기본적으로는 흰색의 값을 가지도록 했습니다.
  - getRepresentation()은 부모 생성자(Piece의 생성자)를 호출해서 representation필드를 읽어옵니다.

#### main/chess

- Board.java

  - 기존의 board 리스트를 `whitePieces`, `blackPieces`로 각각 나누어서 저장하도록 했습니다.
  - 기존의 add 메서드를 색깔별로 `addWhite`, `addBlack`으로 나누었습니다.
  - find메서드도 `findWhite`, `findBlack`으로 나누었습니다.
  - `initialize()` : `BOARD_SIZE`라는 상수를 필드에 선언하여, 그 크기만큼 체스말들을 리스트에 추가합니다.
  - `getPiecesResult(List<Piece) pieces)` : 체스말 리스트를 매개변수로 받아서 해당 말의 표기문자를 문자열에 하나씩 붙여서 리턴합니다.
  - `getBlackPawnsResult()`와 `getWhitePawnsResult()`는 `getPiecesResult()`를 호출하는데, 색깔별 체스말의 리스트를 넘겨줍니다. 추후에는 `getBlackResult()`, `getWhiteResult()`로 변경하여 전체 결과를 가져올 수 있도록 해야합니다.
  - `print()` : 폰 이외에 빈칸을 `.`으로 모두 채우고 폰의 위치에 `getWhitePawnsResult()`, `getBlackPawnsResult()`로 가져온 결과 문자열을 이어붙여서 전체 보드를 출력합니다.

  

#### test/chess

- BoardTest.java
  - `initialize()` : `Board::initialize()`호출 후 각 색깔의 폰 리스트가 적절히 초기화 되었는지 테스트합니다.
  - 이전에 작성한 메서드들은 우선은 if문으로 분기하여 실행할 수 있도록 변경했습니다.
  - `assertEquals()` 보다 `assertThat()`이 장점이 많다는 것을 학습하여 `assertThat()`으로 변경했습니다.