### PR TITLE
[Tree]미션2 체스판 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,8 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     compile('ch.qos.logback:logback-classic:1.2.3')
-    testCompile("org.junit.jupiter:junit-jupiter-api:5.6.0")
     testCompile("org.assertj:assertj-core:3.11.1")
+    testCompile 'junit:junit:4.12'
 }

--- a/src/main/java/net/tree/chess/Board.java
+++ b/src/main/java/net/tree/chess/Board.java
@@ -1,0 +1,26 @@
+package net.tree.chess;
+
+import net.tree.pieces.Pawn;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Board {
+
+    List<Pawn> pawnList = new ArrayList<>();
+
+    public void add(Pawn pawnColor) {
+        pawnList.add(pawnColor);
+    }
+
+    public int size() {
+        return pawnList.size();
+    }
+
+    public Pawn findPawn(int i) {
+
+        Pawn pawn = pawnList.get(i);
+
+        return pawn;
+    }
+}

--- a/src/main/java/net/tree/chess/Pawn.java
+++ b/src/main/java/net/tree/chess/Pawn.java
@@ -1,0 +1,14 @@
+package net.tree.chess;
+
+public class Pawn {
+    String color;
+
+    public Pawn(String color) {
+        this.color = color;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+}

--- a/src/main/java/net/tree/chess/Pawn.java
+++ b/src/main/java/net/tree/chess/Pawn.java
@@ -3,6 +3,9 @@ package net.tree.chess;
 public class Pawn {
     String color;
 
+    final String WHITE = "white";
+    final String BLACK = "black";
+
     public Pawn() {
         this.color = "white";
     }

--- a/src/main/java/net/tree/chess/Pawn.java
+++ b/src/main/java/net/tree/chess/Pawn.java
@@ -3,6 +3,11 @@ package net.tree.chess;
 public class Pawn {
     String color;
 
+    public Pawn() {
+        this.color = "white";
+    }
+
+
     public Pawn(String color) {
         this.color = color;
     }

--- a/src/main/java/net/tree/pieces/Pawn.java
+++ b/src/main/java/net/tree/pieces/Pawn.java
@@ -1,0 +1,22 @@
+package net.tree.pieces;
+
+public class Pawn {
+    String color;
+
+    public static final String WHITE_COLOR = "white";
+    public static final String BLACK_COLOR = "black";
+
+    public Pawn() {
+        this.color = WHITE_COLOR;
+    }
+
+
+    public Pawn(String color) {
+        this.color = color;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+}

--- a/src/test/PawnTest.java
+++ b/src/test/PawnTest.java
@@ -1,0 +1,23 @@
+import net.tree.chess.Pawn;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+public class PawnTest {
+
+    @Test
+    @DisplayName("흰색 폰이 생성되어야 한다")
+    public void create() {
+        verifyPawn("white");
+        verifyPawn("black");
+//        Pawn pawn = new Pawn("white");
+//        assertThat(pawn.getColor()).isEqualTo("white");
+    }
+
+    void verifyPawn(final String color) {
+        Pawn pawn = new Pawn(color);
+        assertEquals(color, pawn.getColor());
+    }
+}

--- a/src/test/java/net/tree.chess/BoardTest.java
+++ b/src/test/java/net/tree.chess/BoardTest.java
@@ -1,0 +1,37 @@
+package net.tree.chess;
+
+import net.tree.pieces.Pawn;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+public class BoardTest {
+
+    @Test
+    public void create() throws Exception {
+        Board board = new Board();
+
+        Pawn white = new Pawn(Pawn.WHITE_COLOR);
+        board.add(white);
+        assertEquals(1, board.size());
+        assertEquals(white, board.findPawn(0));
+
+
+        Pawn black = new Pawn(Pawn.BLACK_COLOR);
+        board.add(black);
+        assertEquals(2, board.size());
+        assertEquals(black, board.findPawn(1));
+
+    }
+
+    @DisplayName("컴파일 에러 발생시키기")
+    @Test
+    public void checkPawnList() throws Exception {
+        Board board = new Board();
+        assertTrue(board.pawnList.add("7"));
+        assertTrue(board.pawnList.add(new Pawn()));
+    }
+}

--- a/src/test/java/net/tree.chess/PawnTest.java
+++ b/src/test/java/net/tree.chess/PawnTest.java
@@ -1,4 +1,5 @@
-import net.tree.chess.Pawn;
+package net.tree.chess;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -12,8 +13,6 @@ public class PawnTest {
     public void create() {
         verifyPawn("white");
         verifyPawn("black");
-//        Pawn pawn = new Pawn("white");
-//        assertThat(pawn.getColor()).isEqualTo("white");
     }
 
     void verifyPawn(final String color) {

--- a/src/test/java/net/tree.chess/PawnTest.java
+++ b/src/test/java/net/tree.chess/PawnTest.java
@@ -21,4 +21,10 @@ public class PawnTest {
         assertEquals(color, pawn.getColor());
         assertThat(color ,equalTo(pawn.getColor()));
     }
+
+    @Test
+    public void create_기본생성자() throws Exception {
+        Pawn pawn = new Pawn();
+        assertEquals("white", pawn.getColor());
+    }
 }

--- a/src/test/java/net/tree.chess/PawnTest.java
+++ b/src/test/java/net/tree.chess/PawnTest.java
@@ -1,10 +1,11 @@
 package net.tree.chess;
 
+
+import org.junit.Test;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.*;
 
 public class PawnTest {
 
@@ -18,5 +19,6 @@ public class PawnTest {
     void verifyPawn(final String color) {
         Pawn pawn = new Pawn(color);
         assertEquals(color, pawn.getColor());
+        assertThat(color ,equalTo(pawn.getColor()));
     }
 }

--- a/src/test/java/net/tree/pieces/PawnTest.java
+++ b/src/test/java/net/tree/pieces/PawnTest.java
@@ -1,0 +1,30 @@
+package net.tree.pieces;
+
+
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.*;
+
+public class PawnTest {
+
+    @Test
+    @DisplayName("흰색 폰이 생성되어야 한다")
+    public void create() {
+        verifyPawn("white");
+        verifyPawn("black");
+    }
+
+    void verifyPawn(final String color) {
+        Pawn pawn = new Pawn(color);
+        assertEquals(color, pawn.getColor());
+        assertThat(color ,equalTo(pawn.getColor()));
+    }
+
+    @Test
+    public void create_기본생성자() throws Exception {
+        Pawn pawn = new Pawn();
+        assertEquals("white", pawn.getColor());
+    }
+}


### PR DESCRIPTION
체스 판에 Pawn 이외의 객체가 추가되지 않도록 한다.
말의 리스트에 new Integer("7")과 같이 Pawn 이외의 객체를 추가해 컴파일 에러가 발생하는지 확인한다.
즉, Pawn 이외의 다른 객체를 추가하면 컴파일 에러가 발생하도록 구현해야 한다.

미션2의 4번 추가 테스트 부분(상기 내용)은 컴파일 에러가 발생할 수 밖에 없도록 코드를 구현해야하는데
그 상태로 PR을 요청하면 되는것인지 아니면 제가 확인하고 지우면 되는것인지 모르겠어서 우선 구현 후 PR 요청드립니다.