### PR TITLE
[Pyro] 미션5 : 보드에 위치 부여 및 점수 계산

### DIFF
--- a/src/main/java/chess/domain/board/Board.java
+++ b/src/main/java/chess/domain/board/Board.java
@@ -15,4 +15,12 @@ public class Board {
     public Piece getPiece(Position position) {
         return squares.get(position);
     }
+
+    public long count(Piece piece) {
+        return squares.entrySet()
+                .stream()
+                .map(Map.Entry::getValue)
+                .filter(piece::equals)
+                .count();
+    }
 }

--- a/src/main/java/chess/domain/board/Board.java
+++ b/src/main/java/chess/domain/board/Board.java
@@ -1,9 +1,13 @@
 package chess.domain.board;
 
 import chess.domain.board.position.Position;
+import chess.domain.pieces.Color;
+import chess.domain.pieces.Pawn;
 import chess.domain.pieces.Piece;
 
 import java.util.Map;
+
+import static chess.domain.board.BoardConst.*;
 
 public class Board {
     private final Map<Position, Piece> squares;
@@ -26,5 +30,36 @@ public class Board {
 
     public void put(Position position, Piece piece) {
         squares.put(position, piece);
+    }
+
+    public double getScore(Color color) {
+        double score = 0;
+        for (char columnId = COLUMN_START; columnId <= COLUMN_END; columnId++) {
+            score += getColumnScore(color, columnId);
+        }
+        return score;
+    }
+
+    private double getColumnScore(Color color, char columnId) {
+        int countOfPawns = 0;
+        double scoreOfPawns = 0;
+        double scoreOfRoyals = 0;
+        
+        for (int rowId = ROW_START; rowId <= ROW_END; rowId++) {
+            Piece piece = squares.get(Position.of(columnId, rowId));
+            if (!piece.isSameColor(color)) {
+                continue;
+            }
+            if (piece instanceof Pawn) {
+                scoreOfPawns += piece.getScore();
+                countOfPawns++;
+                continue;
+            }
+            scoreOfRoyals += piece.getScore();
+        }
+        if (countOfPawns > 1) {
+            scoreOfPawns /= 2;
+        }
+        return scoreOfPawns + scoreOfRoyals;
     }
 }

--- a/src/main/java/chess/domain/board/Board.java
+++ b/src/main/java/chess/domain/board/Board.java
@@ -48,18 +48,27 @@ public class Board {
 
     private double getColumnScore(List<Piece> pieces) {
         double scoreOfRoyals = pieces.stream()
-                .filter(piece -> !(piece instanceof Pawn))
+                .filter(this::isRoyal)
                 .map(Piece::getScore)
                 .reduce((double) 0, Double::sum);
 
         List<Piece> pawns = pieces.stream()
-                .filter(piece -> piece instanceof Pawn)
+                .filter(this::isPawn)
                 .collect(Collectors.toList());
+
         double scoreOfPawns = pawns.stream()
                 .map(Piece::getScore)
                 .reduce((double) 0, Double::sum)
                 * (pawns.size() > 1 ? 0.5 : 1);
 
         return scoreOfRoyals + scoreOfPawns;
+    }
+
+    private boolean isPawn(Piece piece) {
+        return piece.equals(Pawn.ofBlack()) || piece.equals(Pawn.ofWhite());
+    }
+
+    private boolean isRoyal(Piece piece) {
+        return !isPawn(piece);
     }
 }

--- a/src/main/java/chess/domain/board/Board.java
+++ b/src/main/java/chess/domain/board/Board.java
@@ -23,4 +23,8 @@ public class Board {
                 .filter(piece::equals)
                 .count();
     }
+
+    public void put(Position position, Piece piece) {
+        squares.put(position, piece);
+    }
 }

--- a/src/main/java/chess/domain/board/position/Position.java
+++ b/src/main/java/chess/domain/board/position/Position.java
@@ -18,6 +18,10 @@ public class Position {
         return of(positionId);
     }
 
+    public char getColumnId() {
+        return columnId;
+    }
+
     static String getId(char columnId, int rowId) {
         return String.valueOf(columnId) + rowId;
     }

--- a/src/main/java/chess/domain/pieces/Bishop.java
+++ b/src/main/java/chess/domain/pieces/Bishop.java
@@ -10,6 +10,11 @@ public class Bishop extends Piece {
         return 'B';
     }
 
+    @Override
+    public double getScore() {
+        return 3;
+    }
+
     public static Bishop ofWhite() {
         return SingletonHelper.whiteBishop;
     }

--- a/src/main/java/chess/domain/pieces/King.java
+++ b/src/main/java/chess/domain/pieces/King.java
@@ -10,6 +10,11 @@ public class King extends Piece {
         return 'K';
     }
 
+    @Override
+    public double getScore() {
+        return 0;
+    }
+
     public static King ofWhite() {
         return SingletonHelper.whiteKing;
     }

--- a/src/main/java/chess/domain/pieces/Knight.java
+++ b/src/main/java/chess/domain/pieces/Knight.java
@@ -10,6 +10,11 @@ public class Knight extends Piece {
         return 'N';
     }
 
+    @Override
+    public double getScore() {
+        return 2.5;
+    }
+
     public static Knight ofWhite() {
         return SingletonHelper.whiteKnight;
     }

--- a/src/main/java/chess/domain/pieces/NoPiece.java
+++ b/src/main/java/chess/domain/pieces/NoPiece.java
@@ -10,6 +10,11 @@ public class NoPiece extends Piece {
         return '.';
     }
 
+    @Override
+    public double getScore() {
+        return 0;
+    }
+
     public static NoPiece getInstance() {
         return SingletonHelper.instance;
     }

--- a/src/main/java/chess/domain/pieces/Pawn.java
+++ b/src/main/java/chess/domain/pieces/Pawn.java
@@ -10,6 +10,11 @@ public class Pawn extends Piece {
         return 'P';
     }
 
+    @Override
+    public double getScore() {
+        return 1;
+    }
+
     public static Pawn ofWhite() {
         return SingletonHelper.whitePawn;
     }

--- a/src/main/java/chess/domain/pieces/Piece.java
+++ b/src/main/java/chess/domain/pieces/Piece.java
@@ -24,11 +24,8 @@ public abstract class Piece implements Comparable<Piece> {
 
     @Override
     public int compareTo(Piece piece) {
-        double compared = getScore() - piece.getScore();
-        return compared == 0
-                ? 0
-                : compared > 0
-                ? 1
-                : -1;
+        return (int) (2 *
+                (getScore() - piece.getScore())
+        );
     }
 }

--- a/src/main/java/chess/domain/pieces/Piece.java
+++ b/src/main/java/chess/domain/pieces/Piece.java
@@ -24,7 +24,6 @@ public abstract class Piece implements Comparable<Piece> {
 
     @Override
     public int compareTo(Piece piece) {
-        return Double.valueOf(getScore())
-                .compareTo(piece.getScore());
+        return Double.compare(getScore(), piece.getScore());
     }
 }

--- a/src/main/java/chess/domain/pieces/Piece.java
+++ b/src/main/java/chess/domain/pieces/Piece.java
@@ -24,6 +24,7 @@ public abstract class Piece implements Comparable<Piece> {
 
     @Override
     public int compareTo(Piece piece) {
-        return new Double(getScore()).compareTo(piece.getScore());
+        return Double.valueOf(getScore())
+                .compareTo(piece.getScore());
     }
 }

--- a/src/main/java/chess/domain/pieces/Piece.java
+++ b/src/main/java/chess/domain/pieces/Piece.java
@@ -24,8 +24,6 @@ public abstract class Piece implements Comparable<Piece> {
 
     @Override
     public int compareTo(Piece piece) {
-        return (int) (2 *
-                (getScore() - piece.getScore())
-        );
+        return return Double.compareTo(getScore(), piece.getScore();
     }
 }

--- a/src/main/java/chess/domain/pieces/Piece.java
+++ b/src/main/java/chess/domain/pieces/Piece.java
@@ -24,6 +24,6 @@ public abstract class Piece implements Comparable<Piece> {
 
     @Override
     public int compareTo(Piece piece) {
-        return return Double.compareTo(getScore(), piece.getScore();
+        return new Double(getScore()).compareTo(piece.getScore());
     }
 }

--- a/src/main/java/chess/domain/pieces/Piece.java
+++ b/src/main/java/chess/domain/pieces/Piece.java
@@ -1,6 +1,6 @@
 package chess.domain.pieces;
 
-public abstract class Piece {
+public abstract class Piece implements Comparable<Piece> {
     private final char representation;
     private final Color color;
 
@@ -11,8 +11,24 @@ public abstract class Piece {
 
     abstract char getIcon();
 
+    public abstract double getScore();
+
+    public boolean isSameColor(Color color) {
+        return this.color.equals(color);
+    }
+
     @Override
     public String toString() {
         return String.valueOf(representation);
+    }
+
+    @Override
+    public int compareTo(Piece piece) {
+        double compared = getScore() - piece.getScore();
+        return compared == 0
+                ? 0
+                : compared > 0
+                ? 1
+                : -1;
     }
 }

--- a/src/main/java/chess/domain/pieces/Queen.java
+++ b/src/main/java/chess/domain/pieces/Queen.java
@@ -10,6 +10,11 @@ public class Queen extends Piece {
         return 'Q';
     }
 
+    @Override
+    public double getScore() {
+        return 9;
+    }
+
     public static Queen ofWhite() {
         return SingletonHelper.whiteQueen;
     }

--- a/src/main/java/chess/domain/pieces/Rook.java
+++ b/src/main/java/chess/domain/pieces/Rook.java
@@ -10,6 +10,11 @@ public class Rook extends Piece {
         return 'R';
     }
 
+    @Override
+    public double getScore() {
+        return 5;
+    }
+
     public static Rook ofWhite() {
         return SingletonHelper.whiteRook;
     }

--- a/src/test/java/chess/domain/board/BoardTest.java
+++ b/src/test/java/chess/domain/board/BoardTest.java
@@ -1,7 +1,13 @@
 package chess.domain.board;
 
+import chess.domain.pieces.Pawn;
+import chess.domain.pieces.Rook;
 import chess.view.BoardView;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 class BoardTest {
     private Board board;
@@ -11,5 +17,19 @@ class BoardTest {
     void setup() {
         board = BoardFactory.create();
         boardView = new BoardView(board);
+    }
+
+    @Test
+    @DisplayName("까만 폰의 갯수를 센다.")
+    void count_blackPawn() {
+        assertThat(board.count(Pawn.ofBlack()))
+                .isEqualTo(8);
+    }
+
+    @Test
+    @DisplayName("하얀 룩의 갯수를 센다.")
+    void count_whiteRook() {
+        assertThat(board.count(Rook.ofWhite()))
+                .isEqualTo(2);
     }
 }

--- a/src/test/java/chess/domain/board/BoardTest.java
+++ b/src/test/java/chess/domain/board/BoardTest.java
@@ -2,12 +2,14 @@ package chess.domain.board;
 
 import chess.domain.board.position.Position;
 import chess.domain.pieces.Pawn;
+import chess.domain.pieces.Queen;
 import chess.domain.pieces.Rook;
 import chess.view.BoardView;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static chess.utils.StringUtils.NEWLINE;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -48,5 +50,25 @@ class BoardTest {
                 () -> assertThat(board.getPiece(Position.of("h1")))
                         .isEqualTo(Rook.ofWhite())
         );
+    }
+
+    @Test
+    @DisplayName("기물을 체스판 위에 추가")
+    void put() {
+        board.put(Position.of("b5"), Rook.ofBlack());
+        board.put(Position.of("f5"), Queen.ofWhite());
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("  a b c d e f g h ").append(NEWLINE);
+        sb.append("8 R N B Q K B N R ").append(NEWLINE);
+        sb.append("7 P P P P P P P P ").append(NEWLINE);
+        sb.append("6 . . . . . . . . ").append(NEWLINE);
+        sb.append("5 . R . . . q . . ").append(NEWLINE);
+        sb.append("4 . . . . . . . . ").append(NEWLINE);
+        sb.append("3 . . . . . . . . ").append(NEWLINE);
+        sb.append("2 p p p p p p p p ").append(NEWLINE);
+        sb.append("1 r n b q k b n r ").append(NEWLINE);
+        assertThat(boardView.getBoardRepresentation())
+                .isEqualTo(sb.toString());
     }
 }

--- a/src/test/java/chess/domain/board/BoardTest.java
+++ b/src/test/java/chess/domain/board/BoardTest.java
@@ -1,5 +1,6 @@
 package chess.domain.board;
 
+import chess.domain.board.position.Position;
 import chess.domain.pieces.Pawn;
 import chess.domain.pieces.Rook;
 import chess.view.BoardView;
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class BoardTest {
     private Board board;
@@ -31,5 +33,20 @@ class BoardTest {
     void count_whiteRook() {
         assertThat(board.count(Rook.ofWhite()))
                 .isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("주어진 기물의 위치를 조회")
+    void getPiece() {
+        assertAll(
+                () -> assertThat(board.getPiece(Position.of("a8")))
+                        .isEqualTo(Rook.ofBlack()),
+                () -> assertThat(board.getPiece(Position.of("h8")))
+                        .isEqualTo(Rook.ofBlack()),
+                () -> assertThat(board.getPiece(Position.of("a1")))
+                        .isEqualTo(Rook.ofWhite()),
+                () -> assertThat(board.getPiece(Position.of("h1")))
+                        .isEqualTo(Rook.ofWhite())
+        );
     }
 }

--- a/src/test/java/chess/domain/board/BoardTest.java
+++ b/src/test/java/chess/domain/board/BoardTest.java
@@ -1,6 +1,7 @@
 package chess.domain.board;
 
 import chess.domain.board.position.Position;
+import chess.domain.pieces.Color;
 import chess.domain.pieces.Pawn;
 import chess.domain.pieces.Queen;
 import chess.domain.pieces.Rook;
@@ -70,5 +71,31 @@ class BoardTest {
         sb.append("1 r n b q k b n r ").append(NEWLINE);
         assertThat(boardView.getBoardRepresentation())
                 .isEqualTo(sb.toString());
+    }
+
+    @Test
+    @DisplayName("체스 프로그램 점수 계산하기")
+    void getScore() {
+        Board board = DummyBoardFactory.create();
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("  a b c d e f g h ").append(NEWLINE);
+        sb.append("8 . K R . . . . . ").append(NEWLINE);
+        sb.append("7 P . P B . . . . ").append(NEWLINE);
+        sb.append("6 . P . . Q . . . ").append(NEWLINE);
+        sb.append("5 . . . . . . . . ").append(NEWLINE);
+        sb.append("4 . . . . . n q . ").append(NEWLINE);
+        sb.append("3 . . . . . p . p ").append(NEWLINE);
+        sb.append("2 . . . . . p p . ").append(NEWLINE);
+        sb.append("1 . . . . r k . . ").append(NEWLINE);
+
+        assertAll(
+                () -> assertThat(new BoardView(board).getBoardRepresentation())
+                        .isEqualTo(sb.toString()),
+                () -> assertThat(board.getScore(Color.BLACK))
+                        .isEqualTo(20.0),
+                () -> assertThat(board.getScore(Color.WHITE))
+                        .isEqualTo(19.5)
+        );
     }
 }

--- a/src/test/java/chess/domain/board/DummyBoardFactory.java
+++ b/src/test/java/chess/domain/board/DummyBoardFactory.java
@@ -1,0 +1,47 @@
+package chess.domain.board;
+
+import chess.domain.board.position.Position;
+import chess.domain.pieces.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static chess.domain.board.BoardConst.*;
+
+public class DummyBoardFactory {
+    private static Map<Position, Piece> squares;
+
+    private DummyBoardFactory() {}
+
+    public static Board create() {
+        squares = new HashMap<>();
+
+        for (int rowId = ROW_START; rowId <= ROW_END; rowId++) {
+            addEmptyRow(rowId);
+        }
+
+        squares.put(Position.of("b8"), King.ofBlack());
+        squares.put(Position.of("c8"), Rook.ofBlack());
+        squares.put(Position.of("a7"), Pawn.ofBlack());
+        squares.put(Position.of("c7"), Pawn.ofBlack());
+        squares.put(Position.of("d7"), Bishop.ofBlack());
+        squares.put(Position.of("b6"), Pawn.ofBlack());
+        squares.put(Position.of("e6"), Queen.ofBlack());
+        squares.put(Position.of("f4"), Knight.ofWhite());
+        squares.put(Position.of("g4"), Queen.ofWhite());
+        squares.put(Position.of("f3"), Pawn.ofWhite());
+        squares.put(Position.of("h3"), Pawn.ofWhite());
+        squares.put(Position.of("f2"), Pawn.ofWhite());
+        squares.put(Position.of("g2"), Pawn.ofWhite());
+        squares.put(Position.of("e1"), Rook.ofWhite());
+        squares.put(Position.of("f1"), King.ofWhite());
+  
+        return new Board(squares);
+    }
+
+    private static void addEmptyRow(int rowId) {
+        for (char columnId = COLUMN_START; columnId <= COLUMN_END; columnId++) {
+            squares.put(Position.of(columnId, rowId), NoPiece.getInstance());
+        }
+    }
+}

--- a/src/test/java/chess/domain/pieces/PieceTest.java
+++ b/src/test/java/chess/domain/pieces/PieceTest.java
@@ -1,0 +1,45 @@
+package chess.domain.pieces;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class PieceTest {
+
+    @Test
+    @DisplayName("기물의 점수가 낮은 순으로 정렬")
+    void compareTo_increase() {
+        List<Piece> pieces = Arrays.asList(King.ofBlack(), Pawn.ofBlack(), Bishop.ofBlack(), Queen.ofBlack(), Pawn.ofBlack(), Knight.ofBlack(), Rook.ofBlack());
+        Collections.sort(pieces);
+        assertThat(pieces).isEqualTo(Arrays.asList(
+                King.ofBlack(),
+                Pawn.ofBlack(),
+                Pawn.ofBlack(),
+                Knight.ofBlack(),
+                Bishop.ofBlack(),
+                Rook.ofBlack(),
+                Queen.ofBlack()
+        ));
+    }
+
+    @Test
+    @DisplayName("기물의 점수가 높은 순으로 정렬")
+    void compareTo_decrease() {
+        List<Piece> pieces = Arrays.asList(King.ofWhite(), Pawn.ofWhite(), Bishop.ofWhite(), Queen.ofWhite(), Pawn.ofWhite(), Knight.ofWhite(), Rook.ofWhite());
+        Collections.sort(pieces, Collections.reverseOrder());
+        assertThat(pieces).isEqualTo(Arrays.asList(
+                Queen.ofWhite(),
+                Rook.ofWhite(),
+                Bishop.ofWhite(),
+                Knight.ofWhite(),
+                Pawn.ofWhite(),
+                Pawn.ofWhite(),
+                King.ofWhite()
+        ));
+    }
+}


### PR DESCRIPTION
내일이 java-chess 교육과정의 마지막 날인지라,
클린코드 고려치 않고 재빠르게 구현했습니다.

### 1. 기물의 색, 기물의 종류에 따른 enum 구현
색은 Color enum 으로 구현했지만, 기물의 종류는 별도의 싱글톤 클래스로 구현했습니다.


### 2. Piece에 대한 색과 기물에 따라 분리된 팩토리 메소드에서 enum 사용
ofWhite 와 ofBlack 메서드로 구현했습니다.


### 3. 팩토리 메소드 리팩토링
별도로 리팩토링은 하지 않았습니다.


### 4. 체스판의 모든 칸을 Piece로 초기화
지난 미션 4에서 BoardFactory 클래스를 통해 구현했습니다.


### 5. 기물과 색에 해당하는 기물의 개수를 반환
board.count(); 함수로 구현했습니다. 클린하지 않습니다.


### 6. 주어진 위치의 기물을 조회
board.getPiece(); 함수로 지난 미션 4에서 이미 구현했습니다.


### 7. 임의의 기물을 체스판 위에 추가
board.put(); 함수로 구현했습니다.


### 8. 체스 프로그램 점수 계산하기
board.getScore(); 함수를 통해 구현했습니다. 철저하게 함수형으로 구현해보려고 했는데, 잘 안되서 클린하지 않은 코드로 일단 빨리 작성했습니다.


### 9. 기물의 점수가 높은 순으로 정렬
Piece 클래스에 implements Comparable 을 함으로써 구현했습니다.
